### PR TITLE
Explicitly set MYSQL_USER when only MYSQL_PASS is defined

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -113,7 +113,10 @@ func (dc *Database) getEnvDSN() *url.URL {
 	dbPort := os.Getenv("MYSQL_PORT")
 
 	var user *url.Userinfo
-	if dbUser != "" && dbPass != "" {
+	if dbPass != "" {
+		if dbUser == "" {
+			dbUser = "root"
+		}
 		user = url.UserPassword(dbUser, dbPass)
 	} else {
 		user = url.User(dbUser)


### PR DESCRIPTION
Fixes #223 and makes it possible to execute Subscan containers by directly following the instructions in README.


